### PR TITLE
feat: allow multiple client ids

### DIFF
--- a/.github/workflows/async-build.yml
+++ b/.github/workflows/async-build.yml
@@ -1,0 +1,23 @@
+name: Async Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Build
+        run: cargo build

--- a/.github/workflows/blocking-build.yml
+++ b/.github/workflows/blocking-build.yml
@@ -1,0 +1,23 @@
+name: Blocking Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Build
+        run: cargo build --features blocking

--- a/.github/workflows/wasm-test.yml
+++ b/.github/workflows/wasm-test.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Wasm Test
 
 on:
   push:

--- a/examples/async_client/src/main.rs
+++ b/examples/async_client/src/main.rs
@@ -17,7 +17,7 @@ async fn main() {
     // Usually we use `sub` as the identifier for our user...
     println!("Hello, I am {}", &payload.sub);
 
-    // if you have multiple client_id, you can:
+    // if you have multiple client_ids, you can:
     let client = AsyncClient::new_with_vec(vec![client_id]);
     let payload = client.validate_id_token(id_token).await.unwrap();
     println!("Hello, I am {}", &payload.sub);

--- a/examples/async_client/src/main.rs
+++ b/examples/async_client/src/main.rs
@@ -6,14 +6,19 @@ async fn main() {
     let id_token = "the id_token";
 
     let client = AsyncClient::new(client_id);
-    /// or, if you want to set the default timeout for fetching certificates from Google, e.g, 30 seconds, you can:
-    /// ```rust
-    /// let client = AsyncClient::new(client_id).timeout(time::Duration::from_sec(30));
-    /// ```
+    // or, if you want to set the default timeout for fetching certificates from Google, e.g, 30 seconds, you can:
+    // ```rust
+    // let client = AsyncClient::new(client_id).timeout(time::Duration::from_sec(30));
+    // ```
 
     let payload = client.validate_id_token(id_token).await.unwrap(); // In production, remember to handle this error.
 
     // When we get the payload, that mean the id_token is valid.
     // Usually we use `sub` as the identifier for our user...
+    println!("Hello, I am {}", &payload.sub);
+
+    // if you have multiple client_id, you can:
+    let client = AsyncClient::new_with_vec(vec![client_id]);
+    let payload = client.validate_id_token(id_token).await.unwrap();
     println!("Hello, I am {}", &payload.sub);
 }

--- a/examples/blocking/src/main.rs
+++ b/examples/blocking/src/main.rs
@@ -5,8 +5,11 @@ fn main() {
     let id_token = "the id_token";
 
     let client = Client::new(client_id);
-
     let payload = client.validate_id_token(id_token).unwrap();
+    println!("Hello, I am {}", &payload.sub);
 
+    // if you have multiple client_ids, you can:
+    let client = Client::new_with_vec(vec![client_id]);
+    let payload = client.validate_id_token(id_token).unwrap();
     println!("Hello, I am {}", &payload.sub);
 }

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -27,18 +27,17 @@ impl AsyncClient {
     /// Create a new async client.
     pub fn new<S: ToString>(client_id: S) -> Self {
         let client_id = client_id.to_string();
-        Self::new_with_vec(vec![client_id])
+        Self::new_with_vec(&[client_id])
     }
 
     pub fn new_with_vec<T, V>(client_ids: T) -> Self
         where
             T: AsRef<[V]>,
-            V: AsRef<str> + Clone,
+            V: AsRef<str>,
     {
         Self {
             client_ids: client_ids
                 .as_ref()
-                .to_vec()
                 .iter()
                 .map(|c| c.as_ref().to_string())
                 .collect(),

--- a/src/validate/id_token.rs
+++ b/src/validate/id_token.rs
@@ -15,11 +15,12 @@ use crate::{GOOGLE_ISS, GooglePayload};
 use crate::Cert;
 use crate::jwt_parser::JwtParser;
 
-pub fn validate_info<S: AsRef<str>>(client_id: S, parser: &JwtParser<GooglePayload>)
-                                             -> anyhow::Result<()>
+pub fn validate_info<T, V>(client_ids: T, parser: &JwtParser<GooglePayload>) -> anyhow::Result<()>
+    where
+        T: AsRef<[V]>,
+        V: AsRef<str>,
 {
-    let client_id = client_id.as_ref();
-    if !client_id.is_empty() && client_id != parser.payload.aud.as_str() {
+    if !client_ids.as_ref().iter().any(|c| c.as_ref() == parser.payload.aud.as_str()) {
         bail!("id_token: audience provided does not match aud claim in the jwt");
     }
 

--- a/src/wasm/client.rs
+++ b/src/wasm/client.rs
@@ -40,7 +40,7 @@ impl Client {
             Err(e) => return Err(format!("{:?}", e)),
         };
 
-        if let Err(e) = id_token::validate_info(&self.client_id, &parser) {
+        if let Err(e) = id_token::validate_info(&[&self.client_id], &parser) {
             return Err(format!("{:?}", e));
         }
 


### PR DESCRIPTION
related issue: https://github.com/caojen/google-oauth/issues/13

This PR adds a new API `AsyncClient::new_with_vec`:
```rust
let c1 = "abcdefg";
let c2 = "123456";

let client = AsyncClient::new_with_vec(vec![c1, c2]);
```