### PR TITLE
Expose reqwest's rustls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 anyhow = { version = "1" }
-reqwest = { version = "0.11" }
+reqwest = { version = "0.11", default-features=false }
 lazy_static = { version = "1" }
 base64 = { version = "0.21" }
 sha256 = { version = "1", default-features = false }
@@ -32,11 +32,13 @@ wasm-bindgen-futures = { version = "0.4.37", optional = true }
 web-time = { version = "0.2.3", optional = true }
 
 [features]
+default = ["reqwest/default-tls"]
 blocking = ["reqwest/blocking"]
 wasm = ["dep:wasm-bindgen-futures", "dep:wasm-bindgen", "dep:web-time"]
+reqwest-rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.10.0"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -138,3 +138,4 @@ If you need to import `wasm` into your project, you can use `google_oauth::Clien
 + `default`: enable `AsyncClient`.
 + `blocking`: enable `Client`.
 + `wasm`: disable `AsyncClient` and `Client`(`blocking`), enable `Client` (`wasm`).
++ `reqwest-rustls`: use rustls as the TLS backend of the Reqwest client


### PR DESCRIPTION
It would be interesting to have the possibility of using reqwest's rustls backend instead of nativetls so users can decide which tls back-end they will choose.

I am particularly using rustls and I would like to be able to share it with google-oauth.