### PR TITLE
Update some dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ readme = "README.md"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 anyhow = { version = "1" }
-reqwest = { version = "0.11", default-features=false }
+reqwest = { version = "0.12", default-features=false }
 lazy_static = { version = "1" }
-base64 = { version = "0.21" }
+base64 = { version = "0.22" }
 sha256 = { version = "1", default-features = false }
-rsa = { version = "0.8.2", features = ["sha2"] }
+rsa = { version = "0.9.6", features = ["sha2"] }
 hex = { version = "0.4" }
 log = { version = "0.4" }
 async-rwlock = { version = "1" }
@@ -39,7 +39,7 @@ reqwest-rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-env_logger = "0.10.0"
+env_logger = "0.11"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/validate/id_token.rs
+++ b/src/validate/id_token.rs
@@ -66,7 +66,7 @@ pub fn validate_rs256(cert: &Cert, msg: &str, sig: &[u8]) -> MyResult<()> {
         BigUint::from_bytes_be(de.as_slice()),
     )?;
 
-    let verifying_key: VerifyingKey<Sha256> = VerifyingKey::new_with_prefix(pk);
+    let verifying_key: VerifyingKey<Sha256> = VerifyingKey::new(pk);
 
     verifying_key.verify(
         msg.as_bytes(),


### PR DESCRIPTION
In new rsa version, VerifiyingKey::new_with_prefix is deprecated, so update that as well