### PR TITLE
Removed Check for Client ID

### DIFF
--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -93,19 +93,8 @@ impl AsyncClient {
     pub async fn validate_id_token<S>(&self, token: S) -> MyResult<GooglePayload>
         where S: AsRef<str>
     {
-        // fast check:
-        // if there is no given client id, simple return without communicating with Google server.
-
-        let client_ids = self.client_ids.read().await;
-
-        if client_ids.is_empty() {
-            return Err(Error::IDTokenClientIDNotFoundError(IDTokenClientIDNotFoundError {
-                get: token.as_ref().to_string(),
-                expected: Default::default(),
-            }))
-        }
-
         let token = token.as_ref();
+        let client_ids = self.client_ids.read().await;
 
         let parser: JwtParser<GooglePayload> = JwtParser::parse(token)?;
 

--- a/src/validate/id_token.rs
+++ b/src/validate/id_token.rs
@@ -19,7 +19,7 @@ pub fn validate_info<T, V>(client_ids: T, parser: &JwtParser<GooglePayload>) -> 
         T: AsRef<[V]>,
         V: AsRef<str>,
 {
-    if !client_ids.as_ref().iter().any(|c| c.as_ref() == parser.payload.aud.as_str()) {
+    if !client_ids.as_ref().is_empty() && !client_ids.as_ref().iter().any(|c| c.as_ref() == parser.payload.aud.as_str()) {
         // bail!("id_token: audience provided does not match aud claim in the jwt");
         Err(IDTokenClientIDNotFoundError::new(&parser.payload.aud, client_ids))?
     }


### PR DESCRIPTION
I think it would be nice to have a possibility to disable check for client_id in case we don't have one but want to verify the token