### PR TITLE
Use async-lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ sha256 = { version = "1", default-features = false }
 rsa = { version = "0.9.6", features = ["sha2"] }
 hex = { version = "0.4" }
 log = { version = "0.4" }
-async-rwlock = { version = "1" }
+async-lock = { version = "3.4" }
 getrandom = { version = "0.2.10", features = ["js"] }
 wasm-bindgen = { version = "0.2.87", optional = true }
 wasm-bindgen-futures = { version = "0.4.37", optional = true }

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use lazy_static::lazy_static;
 use log::debug;
-use async_rwlock::RwLock;
+use async_lock::RwLock;
 use crate::{DEFAULT_TIMEOUT, GOOGLE_OAUTH_V3_USER_INFO_API, GOOGLE_SA_CERTS_URL, GoogleAccessTokenPayload, GooglePayload, MyResult, utils};
 use crate::certs::{Cert, Certs};
 use crate::jwt_parser::JwtParser;


### PR DESCRIPTION
https://crates.io/crates/async-rwlock is not maintained; it is now async-lock